### PR TITLE
FIX dev links

### DIFF
--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -140,8 +140,8 @@ export default class Main extends Component {
         <footer>
             <div className="otherLinks">
               <p> Created by
-              <Link to="http://alessamessineo.com"> Alessa Messineo</Link> &
-              <Link to="http://marcelhamel.com"> Marcel Hamel</Link>
+              <a href="http://alessamessineo.com"> Alessa Messineo</a> &
+              <a href="http://marcelhamel.com"> Marcel Hamel</a>
               </p>
             </div>
           </footer>


### PR DESCRIPTION
LINK react element in Main component doesn't want to link to external sites, merely other pages within SPA. Actually throws error in console. Fixed by changing to standard anchor tag.